### PR TITLE
Init the credentials with the access token if no service account file is available

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ it depends from where your application runs (inside our outside Google Cloud Pla
 
 The current authentication flow is as follows:
 - Check the `quarkus.google.cloud.service-account-location` property, if it exists, use the service account file from this location.
+- Check the access token returned as part of OpenId Connect Authorization Code Grant response after a user has authenticated with
+  Google OpenId Connect provider (see [Quarkus OpenId Connect for Web Applications](https://quarkus.io/guides/security-openid-connect-web-authentication)).
+  This access token can be used to access Google Services on behalf of the currently authenticated user
+  but will be ignored if the `quarkus.google.cloud.accessTokenEnabled` property is set to `false`.
 - Use `GoogleCredentials.getApplicationDefault()` that will search for credentials in multiple places:
     - Credentials file pointed to by the `GOOGLE_APPLICATION_CREDENTIALS` environment variable.
     - Credentials provided by the Google Cloud SDK `gcloud auth application-default login` command.

--- a/common/runtime/pom.xml
+++ b/common/runtime/pom.xml
@@ -17,6 +17,10 @@
             <artifactId>quarkus-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus.security</groupId>
+            <artifactId>quarkus-security</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.auth</groupId>
             <artifactId>google-auth-library-oauth2-http</artifactId>
             <exclusions>

--- a/common/runtime/src/main/java/io/quarkiverse/googlecloudservices/common/GcpConfiguration.java
+++ b/common/runtime/src/main/java/io/quarkiverse/googlecloudservices/common/GcpConfiguration.java
@@ -19,4 +19,17 @@ public class GcpConfiguration {
      */
     @ConfigItem
     public Optional<String> serviceAccountLocation;
+
+    /**
+     * Enable Google Cloud access token authentication
+     * For example, the access token which is returned as part of OpenId Connect Authorization Code Flow
+     * may be used to access Google Cloud services on behalf of the authenticated user.
+     *
+     * Note that if a service account location is configured then the access token will be ignored even if this property is
+     * enabled.
+     *
+     * Disable this property if the default Google Cloud authentication is required.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean accessTokenEnabled = true;
 }

--- a/common/runtime/src/main/java/io/quarkiverse/googlecloudservices/common/GcpCredentialProducer.java
+++ b/common/runtime/src/main/java/io/quarkiverse/googlecloudservices/common/GcpCredentialProducer.java
@@ -3,19 +3,36 @@ package io.quarkiverse.googlecloudservices.common;
 import java.io.FileInputStream;
 import java.io.IOException;
 
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Default;
+import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
+
+import io.quarkus.security.credential.Credential;
+import io.quarkus.security.credential.TokenCredential;
+import io.quarkus.security.identity.SecurityIdentity;
 
 @ApplicationScoped
 public class GcpCredentialProducer {
 
     @Inject
     GcpConfiguration gcpConfiguration;
+
+    @Inject
+    Instance<SecurityIdentity> securityIdentity;
+
+    @PostConstruct
+    public void verifySecurityIdentity() {
+        if (securityIdentity.isResolvable() && securityIdentity.isAmbiguous()) {
+            throw new IllegalStateException("Multiple " + SecurityIdentity.class + " beans registered");
+        }
+    }
 
     @Produces
     @Singleton
@@ -24,6 +41,13 @@ public class GcpCredentialProducer {
         if (gcpConfiguration.serviceAccountLocation.isPresent()) {
             try (FileInputStream is = new FileInputStream(gcpConfiguration.serviceAccountLocation.get())) {
                 return GoogleCredentials.fromStream(is);
+            }
+        } else if (gcpConfiguration.accessTokenEnabled && securityIdentity.isResolvable()
+                && !securityIdentity.get().isAnonymous()) {
+            for (Credential cred : securityIdentity.get().getCredentials()) {
+                if (cred instanceof TokenCredential && "bearer".equals(((TokenCredential) cred).getType())) {
+                    return GoogleCredentials.create(new AccessToken(((TokenCredential) cred).getToken(), null));
+                }
             }
         }
 


### PR DESCRIPTION
@loicmathieu Hi Loic, here is the draft PR to support the injected access tokens, but only if the security account file is not available. I just need to make sure that when `quarkus-oidc` is on the classpath, then, with both `IdTokenCredential` and `AccessTokenCredential` being produced, it is the latter which is injected into `TokenCredential`...
Maybe going forward a map of credentials can be introduced, for example, when more than one service is used and one can only work with the service account (`PubSub`), the other one like `BigQuery` should use access token, etc...but this simple PR should do for now.

`quarkus-security` is a very light dependency and it should be OK linking these services with it as it also has other types of credentials which might become useful in time 