### PR TITLE
Modify Quarkus Storage extension to rely on official GraalVM configs

### DIFF
--- a/storage/deployment/pom.xml
+++ b/storage/deployment/pom.xml
@@ -26,11 +26,6 @@
             <artifactId>quarkus-google-cloud-storage</artifactId>
             <version>0.3.0-SNAPSHOT</version>
         </dependency>
-        <dependency>
-            <groupId>com.google.cloud</groupId>
-            <artifactId>google-cloud-graalvm-support</artifactId>
-            <version>0.1.0</version>
-        </dependency>
     </dependencies>
 
     <build>

--- a/storage/deployment/pom.xml
+++ b/storage/deployment/pom.xml
@@ -26,6 +26,11 @@
             <artifactId>quarkus-google-cloud-storage</artifactId>
             <version>0.3.0-SNAPSHOT</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-graalvm-support</artifactId>
+            <version>0.1.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/storage/deployment/src/main/java/io/quarkiverse/googlecloudservices/storage/deployment/StorageBuildSteps.java
+++ b/storage/deployment/src/main/java/io/quarkiverse/googlecloudservices/storage/deployment/StorageBuildSteps.java
@@ -1,27 +1,12 @@
 package io.quarkiverse.googlecloudservices.storage.deployment;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
-
-import org.jboss.jandex.ClassInfo;
-import org.jboss.jandex.DotName;
-import org.jboss.jandex.Type;
-
 import io.quarkiverse.googlecloudservices.storage.runtime.StorageProducer;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
-import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
-import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
-import io.quarkus.deployment.builditem.IndexDependencyBuildItem;
-import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 
 public class StorageBuildSteps {
     private static final String FEATURE = "google-cloud-storage";
-
-    private static final DotName DOTNAME_GENERIC_JSON = DotName.createSimple("com.google.api.client.json.GenericJson");
 
     @BuildStep
     public FeatureBuildItem feature() {
@@ -31,45 +16,5 @@ public class StorageBuildSteps {
     @BuildStep
     public AdditionalBeanBuildItem producer() {
         return new AdditionalBeanBuildItem(StorageProducer.class);
-    }
-
-    @BuildStep
-    public IndexDependencyBuildItem indexModelDependency() {
-        // index the 'google-api-services-storage' library as it contains all model classes that needs to be registered for reflection
-        return new IndexDependencyBuildItem("com.google.apis", "google-api-services-storage");
-    }
-
-    @BuildStep
-    public void registerModelForReflection(CombinedIndexBuildItem combinedIndexBuildItem,
-            BuildProducer<ReflectiveClassBuildItem> reflectiveClassBuildItem) {
-        // The BigQuery library uses request classes that extends the GenericJson class and are then serialized in JSON using reflection.
-        Collection<ClassInfo> allKnownImplementors = combinedIndexBuildItem.getIndex()
-                .getAllKnownSubclasses(DOTNAME_GENERIC_JSON);
-        for (ClassInfo candidate : allKnownImplementors) {
-            DotName dotName = candidate.name();
-            Type jandexType = Type.create(dotName, Type.Kind.CLASS);
-            reflectiveClassBuildItem.produce(new ReflectiveClassBuildItem(true, true, jandexType.name().toString()));
-        }
-    }
-
-    @BuildStep
-    public ReflectiveClassBuildItem registerForReflection() {
-        Set<Class> classes = new HashSet<>();
-        // we register for reflection all inner classes and the inner classes fo those inner classes
-        // we may register too many classes but we don't really have the choice here.
-        gatherInnerClasses(classes, com.google.api.services.storage.Storage.class.getDeclaredClasses());
-        return new ReflectiveClassBuildItem(true, true, classes.toArray(new Class[] {}));
-    }
-
-    private void gatherInnerClasses(Set<Class> classes, Class[] registerForReflection) {
-        for (Class<?> theClass : registerForReflection) {
-            // add the inner classes to register for reflection collection
-            Class<?>[] declaredClasses = theClass.getDeclaredClasses();
-            if (declaredClasses.length > 0) {
-                classes.addAll(Arrays.asList(declaredClasses));
-                // there exist some inner classes that have inner classes ...
-                gatherInnerClasses(classes, declaredClasses);
-            }
-        }
     }
 }

--- a/storage/runtime/pom.xml
+++ b/storage/runtime/pom.xml
@@ -21,6 +21,20 @@
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-storage</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.checkerframework</groupId>
+                    <artifactId>checker-qual</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.google.cloud</groupId>

--- a/storage/runtime/pom.xml
+++ b/storage/runtime/pom.xml
@@ -21,20 +21,11 @@
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-storage</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.checkerframework</groupId>
-                    <artifactId>checker-qual</artifactId>
-                </exclusion>
-            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-graalvm-support</artifactId>
+            <version>0.1.0</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
This PR modifies the storage module to rely on the official GCP GraalVM configuration declared here: https://github.com/GoogleCloudPlatform/google-cloud-graalvm-support

If this is satisfactory I can move forward with doing this for Pub/Sub as well which is the other service we believe we have mature support for.

For testing - I manually verified that the integration-test app still works.

cc/ @loicmathieu @meltsufin