### PR TITLE
Upgrade libraries-bom version to latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,15 +23,10 @@
         <quarkus.version>1.9.0.Final</quarkus.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
 
-        <!-- Version 10.0.0 exists but it causes a library dependency issue with micrometer,
-        see https://github.com/micrometer-metrics/micrometer/issues/2249 -->
-        <google-cloud-sdk.version>8.1.0</google-cloud-sdk.version>
+        <google-cloud-sdk.version>16.1.0</google-cloud-sdk.version>
         <!-- The Google Cloud BOM includes the 'android' version of Guava so we need to fix the 'jre' version.
         Make sure to keep these two libraries compatible. -->
         <guava.version>29.0-jre</guava.version>
-        <!-- Google Cloud library BOM has a dependency issue for google-api-client,
-        we fix its version until we can update the BOM.-->
-        <google-api-client.version>1.30.10</google-api-client.version>
     </properties>
 
     <!-- Extension modules. Note that the integration-tests is added via profile to avoid releasing it -->
@@ -67,11 +62,6 @@
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>${guava.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.api-client</groupId>
-                <artifactId>google-api-client</artifactId>
-                <version>${google-api-client.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <google-cloud-sdk.version>16.1.0</google-cloud-sdk.version>
         <!-- The Google Cloud BOM includes the 'android' version of Guava so we need to fix the 'jre' version.
         Make sure to keep these two libraries compatible. -->
-        <guava.version>29.0-jre</guava.version>
+        <guava.version>30.0-jre</guava.version>
     </properties>
 
     <!-- Extension modules. Note that the integration-tests is added via profile to avoid releasing it -->


### PR DESCRIPTION
Try to upgrade the `libraries-bom` to the latest version.

@loicmathieu - I noticed our Spring Cloud GCP project was able to use the latest `libraries-bom` version with `micrometer-registry-stackdriver`; maybe the latest libraries-bom version resolves the issue that you encountered earlier.

Our output for `mvn dependency:tree` looked like this for us:

```
[ESC[1;34mINFOESC[m] +- org.springframework.boot:spring-boot-starter-actuator:jar:2.4.0:compile
[ESC[1;34mINFOESC[m] |  +- org.springframework.boot:spring-boot-actuator-autoconfigure:jar:2.4.0:compile
[ESC[1;34mINFOESC[m] |  \- io.micrometer:micrometer-core:jar:1.6.1:compile
[ESC[1;34mINFOESC[m] |     +- org.hdrhistogram:HdrHistogram:jar:2.1.12:compile
[ESC[1;34mINFOESC[m] |     \- org.latencyutils:LatencyUtils:jar:2.0.3:runtime

// Micrometer deps here
[ESC[1;34mINFOESC[m] +- io.micrometer:micrometer-registry-stackdriver:jar:1.6.1:compile
[ESC[1;34mINFOESC[m] |  \- com.google.cloud:google-cloud-monitoring:jar:2.0.6:compile
[ESC[1;34mINFOESC[m] |     \- com.google.api.grpc:proto-google-cloud-monitoring-v3:jar:2.0.6:compile

[ESC[1;34mINFOESC[m] +- commons-io:commons-io:jar:2.5:test
[ESC[1;34mINFOESC[m] +- org.codehaus.janino:janino:jar:3.1.2:test
[ESC[1;34mINFOESC[m] |  \- org.codehaus.janino:commons-compiler:jar:3.1.2:test
```

Just wanted to give this a try and see if it passes the tests. For me the `main/` integration tests still seemed to work.

cc/ @meltsufin