### PR TITLE
Move GRPC substitutions to a common lib

### DIFF
--- a/bigtable/runtime/pom.xml
+++ b/bigtable/runtime/pom.xml
@@ -18,6 +18,11 @@
             <version>0.4.0-SNAPSHOT</version>
         </dependency>
         <dependency>
+            <groupId>io.quarkiverse.googlecloudservices</groupId>
+            <artifactId>quarkus-google-cloud-common-grpc</artifactId>
+            <version>0.4.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-bigtable</artifactId>
             <exclusions>
@@ -34,16 +39,12 @@
                     <artifactId>checker-qual</artifactId>
                 </exclusion>
                 <!-- We exclude the grpc-netty-shaded library and include only the grpc-netty
-                     one as netty is already included with Quarkus -->
+                     one (coming from quarkus-google-cloud-common-grpc) as netty is already included with Quarkus -->
                 <exclusion>
                     <groupId>io.grpc</groupId>
                     <artifactId>grpc-netty-shaded</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>grpc-netty</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/common/grpc/pom.xml
+++ b/common/grpc/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>io.quarkiverse.googlecloudservices</groupId>
+        <artifactId>quarkus-google-cloud-common-parent</artifactId>
+        <version>0.4.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-google-cloud-common-grpc</artifactId>
+    <name>Quarkus - Google Cloud Services - Common - GRPC</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.api</groupId>
+            <artifactId>gax-grpc</artifactId>
+            <exclusions>
+                <!-- We exclude the grpc-netty-shaded library as grpc-netty is included directly
+                 and Quarkus includes the netty library -->
+                <exclusion>
+                    <groupId>io.grpc</groupId>
+                    <artifactId>grpc-netty-shaded</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-netty</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.graalvm.nativeimage</groupId>
+            <artifactId>svm</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/common/grpc/src/main/java/io/quarkiverse/googlecloudservices/common/grpc/runtime/graal/GoogleApiGaxGrpcSubstitutions.java
+++ b/common/grpc/src/main/java/io/quarkiverse/googlecloudservices/common/grpc/runtime/graal/GoogleApiGaxGrpcSubstitutions.java
@@ -1,4 +1,4 @@
-package io.quarkiverse.googlecloudservices.pubsub.runtime.graal;
+package io.quarkiverse.googlecloudservices.common.grpc.runtime.graal;
 
 import java.io.IOException;
 import java.util.concurrent.Executor;
@@ -15,7 +15,13 @@ import com.oracle.svm.core.annotate.Alias;
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
 
-import io.grpc.*;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.MethodDescriptor;
 
 @TargetClass(className = "com.google.api.gax.grpc.InstantiatingGrpcChannelProvider")
 final class Target_com_google_api_gax_grpc_InstantiatingGrpcChannelProvider {

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -15,6 +15,7 @@
     <modules>
         <module>deployment</module>
         <module>runtime</module>
+        <module>grpc</module>
     </modules>
 
 

--- a/firestore/runtime/pom.xml
+++ b/firestore/runtime/pom.xml
@@ -19,6 +19,11 @@
             <version>0.4.0-SNAPSHOT</version>
         </dependency>
         <dependency>
+            <groupId>io.quarkiverse.googlecloudservices</groupId>
+            <artifactId>quarkus-google-cloud-common-grpc</artifactId>
+            <version>0.4.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-firestore</artifactId>
             <exclusions>
@@ -35,7 +40,7 @@
                     <artifactId>checker-qual</artifactId>
                 </exclusion>
                 <!-- We exclude the grpc-netty-shaded library and include only the grpc-netty
-                one as netty is already included with Quarkus -->
+                one (coming from quarkus-google-cloud-common-grpc) as netty is already included with Quarkus -->
                 <exclusion>
                     <groupId>io.grpc</groupId>
                     <artifactId>grpc-netty-shaded</artifactId>

--- a/integration-tests/main/src/main/resources/application.properties
+++ b/integration-tests/main/src/main/resources/application.properties
@@ -1,3 +1,6 @@
 # Fill the following properties to run the application
-quarkus.google.cloud.service-account-location=
-quarkus.google.cloud.project-id=my-project-id
+#quarkus.google.cloud.service-account-location=
+#quarkus.google.cloud.project-id=my-project-id
+quarkus.google.cloud.service-account-location=/data/dev/keys/methodical-mesh-238712-f1780e213891.json
+quarkus.google.cloud.project-id=methodical-mesh-238712
+%test.quarkus.google.cloud.project-id=test-project

--- a/pubsub/runtime/pom.xml
+++ b/pubsub/runtime/pom.xml
@@ -19,6 +19,11 @@
             <version>0.4.0-SNAPSHOT</version>
         </dependency>
         <dependency>
+            <groupId>io.quarkiverse.googlecloudservices</groupId>
+            <artifactId>quarkus-google-cloud-common-grpc</artifactId>
+            <version>0.4.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-pubsub</artifactId>
             <exclusions>
@@ -34,17 +39,13 @@
                     <groupId>org.checkerframework</groupId>
                     <artifactId>checker-qual</artifactId>
                 </exclusion>
-                <!-- We exclude the grpc-netty-shaded library and include only the grpc-netty
-                one as netty is already included with Quarkus -->
+                <!-- We exclude the grpc-netty-shaded library as grpc-netty is included via
+                quarkus-google-cloud-common-grpc and Quarkus includes the netty library -->
                 <exclusion>
                     <groupId>io.grpc</groupId>
                     <artifactId>grpc-netty-shaded</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>grpc-netty</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/spanner/runtime/pom.xml
+++ b/spanner/runtime/pom.xml
@@ -19,6 +19,11 @@
             <version>0.4.0-SNAPSHOT</version>
         </dependency>
         <dependency>
+            <groupId>io.quarkiverse.googlecloudservices</groupId>
+            <artifactId>quarkus-google-cloud-common-grpc</artifactId>
+            <version>0.4.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-spanner</artifactId>
             <exclusions>
@@ -31,7 +36,7 @@
                     <artifactId>javax.annotation-api</artifactId>
                 </exclusion>
                 <!-- We exclude the grpc-netty-shaded library and include only the grpc-netty
-                one as netty is already included with Quarkus -->
+                one (coming from quarkus-google-cloud-common-grpc) as netty is already included with Quarkus -->
                 <exclusion>
                     <groupId>io.grpc</groupId>
                     <artifactId>grpc-netty-shaded</artifactId>


### PR DESCRIPTION
This fixes native image for bigtable, firestore and spanner

Fixes #67 and #69 