### PR TITLE
Rely on reflection configurations from google-cloud-graalvm-support

### DIFF
--- a/bigquery/deployment/src/main/java/io/quarkiverse/googlecloudservices/bigquery/deployment/BigQueryBuildSteps.java
+++ b/bigquery/deployment/src/main/java/io/quarkiverse/googlecloudservices/bigquery/deployment/BigQueryBuildSteps.java
@@ -1,27 +1,12 @@
 package io.quarkiverse.googlecloudservices.bigquery.deployment;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
-
-import org.jboss.jandex.ClassInfo;
-import org.jboss.jandex.DotName;
-import org.jboss.jandex.Type;
-
 import io.quarkiverse.googlecloudservices.bigquery.runtime.BigQueryProducer;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
-import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
-import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
-import io.quarkus.deployment.builditem.IndexDependencyBuildItem;
-import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 
 public class BigQueryBuildSteps {
     private static final String FEATURE = "google-cloud-bigquery";
-
-    private static final DotName DOTNAME_GENERIC_JSON = DotName.createSimple("com.google.api.client.json.GenericJson");
 
     @BuildStep
     public FeatureBuildItem feature() {
@@ -31,45 +16,5 @@ public class BigQueryBuildSteps {
     @BuildStep
     public AdditionalBeanBuildItem producer() {
         return new AdditionalBeanBuildItem(BigQueryProducer.class);
-    }
-
-    @BuildStep
-    public IndexDependencyBuildItem indexModelDependency() {
-        // index the 'google-api-services-bigquery' library as it contains all model classes that needs to be registered for reflection
-        return new IndexDependencyBuildItem("com.google.apis", "google-api-services-bigquery");
-    }
-
-    @BuildStep
-    public void registerModelForReflection(CombinedIndexBuildItem combinedIndexBuildItem,
-            BuildProducer<ReflectiveClassBuildItem> reflectiveClassBuildItem) {
-        // The BigQuery library uses request classes that extends the GenericJson class and are then serialized in JSON using reflection.
-        Collection<ClassInfo> allKnownImplementors = combinedIndexBuildItem.getIndex()
-                .getAllKnownSubclasses(DOTNAME_GENERIC_JSON);
-        for (ClassInfo candidate : allKnownImplementors) {
-            DotName dotName = candidate.name();
-            Type jandexType = Type.create(dotName, Type.Kind.CLASS);
-            reflectiveClassBuildItem.produce(new ReflectiveClassBuildItem(true, true, jandexType.name().toString()));
-        }
-    }
-
-    @BuildStep
-    public ReflectiveClassBuildItem registerBigQueryForReflection() {
-        Set<Class> classes = new HashSet<>();
-        // we register for reflection all inner classes and the inner classes of those inner classes
-        // we may register too many classes but we don't really have a choice here.
-        gatherInnerClasses(classes, com.google.api.services.bigquery.Bigquery.class.getDeclaredClasses());
-        return new ReflectiveClassBuildItem(true, true, classes.toArray(new Class[] {}));
-    }
-
-    private void gatherInnerClasses(Set<Class> classes, Class[] registerForReflection) {
-        for (Class<?> theClass : registerForReflection) {
-            // add the inner classes to register for reflection collection
-            Class<?>[] declaredClasses = theClass.getDeclaredClasses();
-            if (declaredClasses.length > 0) {
-                classes.addAll(Arrays.asList(declaredClasses));
-                // there exist some inner classes that have inner classes ...
-                gatherInnerClasses(classes, declaredClasses);
-            }
-        }
     }
 }

--- a/common/deployment/src/main/java/io/quarkiverse/googlecloudservices/common/deployment/CommonBuildSteps.java
+++ b/common/deployment/src/main/java/io/quarkiverse/googlecloudservices/common/deployment/CommonBuildSteps.java
@@ -4,26 +4,8 @@ import io.quarkiverse.googlecloudservices.common.GcpCredentialProducer;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
-import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 
 public class CommonBuildSteps {
-
-    private static final String[] REGISTER_FOR_REFLECTION = {
-            "com.google.api.client.json.GenericJson",
-            "com.google.api.client.googleapis.json.GoogleJsonError",
-            "com.google.api.client.googleapis.json.GoogleJsonError$ErrorInfo",
-            "com.google.api.client.util.GenericData",
-            "com.google.api.client.json.webtoken.JsonWebSignature",
-            "com.google.api.client.json.webtoken.JsonWebToken$Payload",
-            "com.google.api.client.json.webtoken.JsonWebToken$Header",
-            "com.google.api.client.json.webtoken.JsonWebSignature$Header",
-            "com.google.api.client.json.webtoken.JsonWebToken$Payload"
-    };
-
-    @BuildStep
-    public ReflectiveClassBuildItem registerForReflection() {
-        return new ReflectiveClassBuildItem(true, true, REGISTER_FOR_REFLECTION);
-    }
 
     @BuildStep
     public AdditionalBeanBuildItem producer() {

--- a/common/runtime/pom.xml
+++ b/common/runtime/pom.xml
@@ -35,6 +35,10 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-graalvm-support</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>commons-logging-jboss-logging</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
 
         <google-cloud-sdk.version>16.1.0</google-cloud-sdk.version>
+        <google-cloud-graalvm.version>0.2.0</google-cloud-graalvm.version>
         <!-- The Google Cloud BOM includes the 'android' version of Guava so we need to fix the 'jre' version.
         Make sure to keep these two libraries compatible. -->
         <guava.version>30.0-jre</guava.version>
@@ -62,6 +63,11 @@
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>${guava.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.cloud</groupId>
+                <artifactId>google-cloud-graalvm-support</artifactId>
+                <version>${google-cloud-graalvm.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/spanner/deployment/src/main/java/io/quarkiverse/googlecloudservices/spanner/deployment/SpannerBuildSteps.java
+++ b/spanner/deployment/src/main/java/io/quarkiverse/googlecloudservices/spanner/deployment/SpannerBuildSteps.java
@@ -4,15 +4,9 @@ import io.quarkiverse.googlecloudservices.spanner.runtime.SpannerProducer;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
-import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 
 public class SpannerBuildSteps {
     private static final String FEATURE = "google-cloud-spanner";
-
-    @BuildStep
-    public ReflectiveClassBuildItem registerForReflection() {
-        return new ReflectiveClassBuildItem(true, true, "com.google.protobuf.Empty");
-    }
 
     @BuildStep
     public FeatureBuildItem feature() {

--- a/storage/runtime/pom.xml
+++ b/storage/runtime/pom.xml
@@ -36,11 +36,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
-            <groupId>com.google.cloud</groupId>
-            <artifactId>google-cloud-graalvm-support</artifactId>
-            <version>0.1.0</version>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Hey Loic,

We just released version `0.2.0` of [`google-cloud-graalvm-support`](https://github.com/GoogleCloudPlatform/google-cloud-graalvm-support) and added reflection configurations for several new libraries including Spanner, Firestore, BigQuery, Bigtable, etc. The configurations are conditionally added -- so for example, we use the GraalVM SDK to determine whether say Spanner libraries are on the classpath, and only add the Spanner configurations if that is true.

I think our project is now mature enough to start officially supporting the reflection configuration needs for Google libraries as a whole. This PR migrates the quarkus extension to depend on the `google-cloud-graalvm-support` dependency for all the modules.

Testing: I ran the integration test main and was able to verify manually that the endpoints for the six services still work.

Here is the PR for your consideration; let me know if you feel ready to make the transition!

cc/ @meltsufin